### PR TITLE
New Logical Implementation

### DIFF
--- a/.bot_state.json
+++ b/.bot_state.json
@@ -1,0 +1,5 @@
+{
+  "date": "",
+  "daily_target": 0,
+  "completed": 0
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,25 +2,26 @@ name: Daily Contribution
 
 on:
     schedule:
-        - cron: "30 4,15 * * *" # Runs at 10:00 IST and 21:00 IST
-    workflow_dispatch: # Allow manual trigger
-        inputs:
-            test_mode:
-                description: 'Run in test mode (bypass time check)?'
-                required: false
-                default: false
-                type: boolean
+        - cron: "0 * * * *" # Runs hourly; script enforces the daily random quota
+    workflow_dispatch:
+
+concurrency:
+    group: contrib-bot
+    cancel-in-progress: false
 
 jobs:
     build:
         runs-on: ubuntu-latest
         permissions:
-            contents: write # Needed to push commits
-            issues: write # Needed to create issues
+            contents: write
+            issues: write
+            pull-requests: write
 
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
             - name: Set up Python
               uses: actions/setup-python@v4
@@ -42,11 +43,5 @@ jobs:
                   PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
                   GH_USERNAME: ${{ secrets.COMMIT_USERNAME }}
-                  TEST_MODE: ${{ github.event.inputs.test_mode }}
               run: |
                   python Automator.py
-
-            - name: Cleanup
-              run: |
-                   git checkout main
-                   git pull origin main

--- a/Automator.py
+++ b/Automator.py
@@ -1,117 +1,186 @@
-''' 
-Author : Pareekshith1 {Pareekshith.P} 
-'''
+"""
+Author : Pareekshith1 {Pareekshith.P}
+"""
+import json
 import os
 import random
-import sys
-import time
-from datetime import datetime
-from git import Repo
+from datetime import datetime, timezone
+
 import github
+from git import Repo
 from github import Github
 
-# Configuration
 REPO_PATH = os.getcwd()
+BASE_BRANCH = "main"
 FILE_TO_UPDATE = "contribution_log.txt"
+STATE_FILE = ".bot_state.json"
+LABELS = ["updation"]
 
-def get_random_comment():
+
+def get_random_review():
     comments = [
-        "Great changes! LGTM.",
-        "Looks good to me. Ready to merge.",
-        "Nice work on this update.",
-        "Everything looks correct. Good job!",
-        "Verified the changes, they look solid.",
-        "Excellent improvements. Approved.",
-        "Clean code, thanks for the contribution.",
-        "This is exactly what was needed."
+        "Reviewed the automated update. Approved.",
+        "Change looks valid and ready to merge.",
+        "Verified the generated update. Approving.",
+        "Checked the update branch and approved the PR.",
+        "Automated review completed successfully.",
     ]
     return random.choice(comments)
 
-def main():
-    # 0. Time-based restriction (10:00 AM & 9:00 PM IST)
-    # 10:00 IST = 04:30 UTC
-    # 21:00 IST = 15:30 UTC
-    now = datetime.utcnow()
-    # 04:30 - 04:31 UTC (10:00 - 10:01 AM IST)
-    # 15:30 - 15:31 UTC (09:00 - 09:01 PM IST)
-    is_morning_slot = now.hour == 4 and (30 <= now.minute <= 31)
-    is_evening_slot = now.hour == 15 and (30 <= now.minute <= 31)
-    test_mode = os.environ.get("TEST_MODE") == "true"
-    
-    if not (is_morning_slot or is_evening_slot or test_mode):
-        current_time_str = now.strftime("%H:%M")
-        print(f"Current time {current_time_str} UTC is outside allowed windows (10:00-10:01 or 21:00-21:01 IST). Exiting.")
-        return
 
+def state_file_path():
+    return os.path.join(REPO_PATH, STATE_FILE)
+
+
+def load_state():
+    path = state_file_path()
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_state(state):
+    with open(state_file_path(), "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2)
+        handle.write("\n")
+
+
+def get_today_state():
+    today = datetime.now(timezone.utc).date().isoformat()
+    state = load_state()
+    if state.get("date") != today:
+        state = {
+            "date": today,
+            "daily_target": random.randint(1, 25),
+            "completed": 0,
+        }
+    return state
+
+
+def sync_main_branch(local_repo):
+    origin = local_repo.remote(name="origin")
+    local_repo.git.checkout(BASE_BRANCH)
+    origin.fetch(BASE_BRANCH)
+    local_repo.git.reset("--hard", f"origin/{BASE_BRANCH}")
+    return origin
+
+
+def commit_state(local_repo, origin, state):
+    save_state(state)
+    local_repo.index.add([STATE_FILE])
+    if not local_repo.is_dirty(untracked_files=True):
+        return
+    local_repo.index.commit(
+        f"bot-state: {state['date']} {state['completed']}/{state['daily_target']}"
+    )
+    origin.push(BASE_BRANCH)
+
+
+def create_cycle_change(local_repo, cycle_number):
+    timestamp = datetime.now(timezone.utc).isoformat()
+    with open(os.path.join(REPO_PATH, FILE_TO_UPDATE), "a", encoding="utf-8") as handle:
+        handle.write(
+            f"\nContribution cycle {cycle_number} executed at {timestamp}"
+        )
+    local_repo.index.add([FILE_TO_UPDATE])
+    local_repo.index.commit(f"Contribution cycle {cycle_number}: {timestamp}")
+
+
+def delete_remote_branch(remote_repo, branch_name):
+    ref = remote_repo.get_git_ref(f"heads/{branch_name}")
+    ref.delete()
+
+
+def run_cycle(local_repo, remote_repo, gh_username, cycle_number):
+    branch_stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    branch_name = f"update-{branch_stamp}-{cycle_number}"
+    local_repo.git.checkout("-b", branch_name)
+    print(f"Switched to branch: {branch_name}")
+
+    create_cycle_change(local_repo, cycle_number)
+
+    origin = local_repo.remote(name="origin")
+    print(f"Pushing branch {branch_name} to remote...")
+    origin.push(refspec=f"{branch_name}:{branch_name}")
+
+    issue_title = f"Task for {datetime.now(timezone.utc).strftime('%Y-%m-%d')} #{cycle_number}"
+    issue_body = "This issue is created automatically to track contribution activity."
+    issue = remote_repo.create_issue(
+        title=issue_title,
+        body=issue_body,
+        assignee=gh_username,
+        labels=LABELS,
+    )
+    print(f"Created issue #{issue.number}")
+
+    pr_title = f"Feature: Contribution cycle {cycle_number}"
+    pr_body = (
+        "This PR contains an automated contribution update.\n\n"
+        f"Closes #{issue.number}"
+    )
+    pr = remote_repo.create_pull(
+        title=pr_title,
+        body=pr_body,
+        base=BASE_BRANCH,
+        head=branch_name,
+    )
+    pr.add_to_assignees(gh_username)
+    pr.add_to_labels(*LABELS)
+    print(f"Created PR #{pr.number}: {pr.html_url}")
+
+    pr.create_review(body=get_random_review(), event="APPROVE")
+    print(f"Approved PR #{pr.number}")
+
+    merge_status = pr.merge(
+        merge_method="squash",
+        commit_message=f"Merged automated contribution PR #{pr.number}",
+    )
+    if not merge_status.merged:
+        raise RuntimeError(f"Failed to merge PR #{pr.number}: {merge_status.message}")
+
+    print(f"PR #{pr.number} merged successfully")
+
+    delete_remote_branch(remote_repo, branch_name)
+    print(f"Deleted remote branch {branch_name}")
+
+    local_repo.git.checkout(BASE_BRANCH)
+    local_repo.git.branch("-D", branch_name)
+
+
+def main():
     token = os.environ.get("PAT_TOKEN")
     repo_name = os.environ.get("GITHUB_REPOSITORY")
     gh_username = os.environ.get("GH_USERNAME")
 
     if not all([token, repo_name, gh_username]):
-        print("Error: PAT_TOKEN, GITHUB_REPOSITORY, and GH_USERNAME must be set.")
+        raise RuntimeError("PAT_TOKEN, GITHUB_REPOSITORY, and GH_USERNAME must be set.")
+
+    client = Github(auth=github.Auth.Token(token))
+    remote_repo = client.get_repo(repo_name)
+    local_repo = Repo(REPO_PATH)
+    origin = sync_main_branch(local_repo)
+
+    state = get_today_state()
+    print(
+        f"Daily target: {state['daily_target']} | Completed today: {state['completed']}"
+    )
+
+    if state["completed"] >= state["daily_target"]:
+        print("Daily quota already met. Exiting.")
+        commit_state(local_repo, origin, state)
         return
 
-    g = Github(auth=github.Auth.Token(token))
-    remote_repo = g.get_repo(repo_name)
-    local_repo = Repo(REPO_PATH)
+    cycle_number = state["completed"] + 1
+    run_cycle(local_repo, remote_repo, gh_username, cycle_number)
 
-    # 1. Create a unique branch
-    now_str = datetime.now().strftime('%Y%m%d%H%M%S')
-    branch_name = f"contribution-{now_str}"
-    new_branch = local_repo.create_head(branch_name)
-    new_branch.checkout()
-    print(f"Switched to new branch: {branch_name}")
+    origin = sync_main_branch(local_repo)
+    state["completed"] = cycle_number
+    commit_state(local_repo, origin, state)
+    print(
+        f"Updated daily state: {state['completed']}/{state['daily_target']} completed"
+    )
 
-    # 2. Make changes and commit
-    num_commits = random.randint(1, 20) 
-    print(f"Generating {num_commits} commits.")
-
-    for i in range(num_commits):
-        with open(os.path.join(REPO_PATH, FILE_TO_UPDATE), "a") as f:
-            f.write(f"\nContribution {i+1} on {datetime.now()}")
-        
-        local_repo.index.add([FILE_TO_UPDATE])
-        local_repo.index.commit(f"Contribution {i+1}: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-
-    # 3. Push the branch
-    print(f"Pushing branch {branch_name} to remote...")
-    origin = local_repo.remote(name='origin')
-    origin.push(branch_name)
-
-    # 4. Create an issue and assign to user
-    print("Creating issue...")
-    issue_title = f"Task for {datetime.now().strftime('%Y-%m-%d')}"
-    issue_body = "This issue is created automatically to track daily contributions."
-    issue = remote_repo.create_issue(title=issue_title, body=issue_body, assignee=gh_username, labels=["updation"])
-    print(f"Created issue #{issue.number} and assigned to {gh_username}")
-
-    # 5. Create PR
-    print("Creating Pull Request...")
-    pr_title = f"Feature: Contribution {datetime.now().strftime('%Y-%m-%d')}"
-    pr_body = f"This PR addresses the work for today.\n\nCloses #{issue.number}"
-    pr = remote_repo.create_pull(title=pr_title, body=pr_body, base="main", head=branch_name)
-    print(f"Created PR #{pr.number}: {pr.html_url}")
-
-    # 5b. Assign to user and add labels
-    pr.add_to_assignees(gh_username)
-    pr.add_to_labels("updation")
-    print(f"Assigned PR #{pr.number} to {gh_username} with 'updation' label")
-
-    # Wait a bit for GitHub to process
-    time.sleep(5)
-
-    # 6. Make a random review/comment
-    print("Submitting automated comment...")
-    pr.create_issue_comment(get_random_comment())
-    print("Comment submitted.")
-
-    # 7. Merge the PR
-    print("Merging PR...")
-    merge_status = pr.merge(merge_method="squash", commit_message=f"Merged automated contribution PR #{pr.number}")
-    if merge_status.merged:
-        print(f"PR #{pr.number} merged successfully!")
-    else:
-        print(f"Failed to merge PR #{pr.number}: {merge_status.message}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
 In Automator.py, the old fixed 10 AM / 9 PM UTC-window logic was removed. The script now keeps daily state in .bot_state.json,
  generates a random daily target from 1..25, and tracks how many cycles have already completed today. Each workflow run performs
  at most one full lifecycle: create and assign an issue, create a fresh update-* branch from main, change contribution_log.txt,
  open and assign a PR, submit a real approval review, merge it into main, delete the temporary branch, then update the daily
  counter. If the daily target is already met, the script exits without doing more work.

  In main.yml, the workflow was simplified to run only on schedule and workflow_dispatch, with an hourly cron and concurrency
  enabled so runs cannot overlap. The manual TEST_MODE path and the cleanup step were removed, fetch-depth: 0 was added for full
  git history, and permissions were expanded to include pull-requests: write. The main effect is that merges to main no longer
  retrigger the automation, so the loop problem is removed while the bot can still steadily generate issues, PRs, reviews, and
  merged commits across the day.